### PR TITLE
test(reloader): fix flaky test TestReloader_ConfigDirApplyBasedOnWatchInterval

### DIFF
--- a/pkg/reloader/reloader_test.go
+++ b/pkg/reloader/reloader_test.go
@@ -614,8 +614,6 @@ func TestReloader_ConfigDirApply(t *testing.T) {
 }
 
 func TestReloader_ConfigDirApplyBasedOnWatchInterval(t *testing.T) {
-	t.Skip("Flaky")
-
 	t.Parallel()
 
 	l, err := net.Listen("tcp", "localhost:0")
@@ -640,7 +638,6 @@ func TestReloader_ConfigDirApplyBasedOnWatchInterval(t *testing.T) {
 	dir2 := t.TempDir()
 
 	outDir := t.TempDir()
-	outDir2 := t.TempDir()
 
 	// dir
 	// └─ rule-dir -> dir2/rule-dir
@@ -662,10 +659,6 @@ func TestReloader_ConfigDirApplyBasedOnWatchInterval(t *testing.T) {
 					Dir:       dir,
 					OutputDir: outDir,
 				},
-				{
-					Dir:       dir2,
-					OutputDir: outDir2,
-				},
 			},
 			WatchedDirs:   nil,
 			WatchInterval: 1 * time.Second, // use a small watch interval.
@@ -683,7 +676,7 @@ func TestReloader_ConfigDirApplyBasedOnWatchInterval(t *testing.T) {
 	// ├─ rule3-001.yaml -> rule3-source.yaml
 	// └─ rule3-source.yaml
 	//
-	// The reloader watches 2 directories: dir and dir/rule-dir.
+	// The reloader watches only 1 directory: dir.
 	testutil.Ok(t, os.WriteFile(path.Join(dir, "rule1.yaml"), []byte("rule"), os.ModePerm))
 	testutil.Ok(t, os.WriteFile(path.Join(dir, "rule2.yaml"), []byte("rule2"), os.ModePerm))
 	testutil.Ok(t, os.WriteFile(path.Join(dir2, "rule3-source.yaml"), []byte("rule3"), os.ModePerm))
@@ -799,27 +792,6 @@ func TestReloader_ConfigDirApplyBasedOnWatchInterval(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Equals(t, "rule2", string(data))
 	data, err = os.ReadFile(filepath.Join(outDir, "rule3.yaml"))
-	testutil.Ok(t, err)
-	testutil.Equals(t, "rule3-changed", string(data))
-
-	outEntries2, err := os.ReadDir(outDir2)
-	testutil.Ok(t, err)
-	outFiles2 := []string{}
-	for _, entry := range outEntries2 {
-		outFiles2 = append(outFiles2, entry.Name())
-	}
-	slices.Sort(outFiles2)
-	expectedOutFiles2 := []string{
-		"rule3-001.yaml",
-		"rule3-source.yaml",
-	}
-	slices.Sort(expectedOutFiles2)
-	testutil.Equals(t, expectedOutFiles2, outFiles2)
-
-	data, err = os.ReadFile(filepath.Join(outDir2, "rule3-001.yaml"))
-	testutil.Ok(t, err)
-	testutil.Equals(t, "rule3-changed", string(data))
-	data, err = os.ReadFile(filepath.Join(outDir2, "rule3-source.yaml"))
 	testutil.Ok(t, err)
 	testutil.Equals(t, "rule3-changed", string(data))
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
- remove `dir2` from `CfgDirs` to prevent the `dir2` from being watched and triggering fsnotify as well as potential  reload
- remove unnecessary test assertions on `outDir2`

## Verification

<!-- How you tested it? How do you know it works? -->
### How you tested it?
I tested on my local machine(MacOS 14.4.1) 50 times with the command:
```
for i in {1..50}; do go test -count=1 -v -race -timeout 10m ./pkg/reloader -run '^TestReloader_ConfigDirApplyBasedOnWatchInterval$' || break; done
```

Before testing, I also set the [logger in the test case](https://github.com/thanos-io/thanos/blob/58f15ea6c047abaa62f0ea7af5d273402ff7dc92/pkg/reloader/reloader_test.go#L652) as below:
```
logger := log.NewLogfmtLogger(os.Stdout)
```
In this way, we could observe the time of reload request being sent.


## The Issue
The test intention is to test if the reloader will wait until the time of `WatchInterval` to apply the changes in directories and to send the reload request at last. In the original test case, the reloader watches both `dir` and `dir2` that will sometimes trigger additional `notify` event in test step 0.

### _The test steps that passed are described as below:_

* **Test Step 0**
  * Create symlink in dir2
→ fires 1st fsnotify from dir2
  * Move file to dir1
→ fires 2nd fsnotify from dir
  * In the end of test step 0, the relaoder triggers 1 reload

* **Test Step 1**:
  * change the content
    * fire 3rd fsnotify
  * In the end of test step 1, the relaoder triggers 1 reload

* **Result**: Pass
* **Observed log in local machine**:
```
=== RUN   TestReloader_ConfigDirApplyBasedOnWatchInterval
=== PAUSE TestReloader_ConfigDirApplyBasedOnWatchInterval
=== CONT  TestReloader_ConfigDirApplyBasedOnWatchInterval
level=info msg="reloading via HTTP"
level=info msg="started watching config file and directories for changes" cfg= cfgDirs=/var/folders/77/n11x5lsj4cv7lcnln0bb5pdcwym47m/T/TestReloader_ConfigDirApplyBasedOnWatchInterval314241190/001,/var/folders/77/n11x5lsj4cv7lcnln0bb5pdcwym47m/T/TestReloader_ConfigDirApplyBasedOnWatchInterval314241190/002 out= dirs=
    reloader_test.go:714: Performing step number 0
level=info msg="Reload triggered" cfg_in= cfg_out= cfg_dirs="/var/folders/77/n11x5lsj4cv7lcnln0bb5pdcwym47m/T/TestReloader_ConfigDirApplyBasedOnWatchInterval314241190/001, /var/folders/77/n11x5lsj4cv7lcnln0bb5pdcwym47m/T/TestReloader_ConfigDirApplyBasedOnWatchInterval314241190/002" watched_dirs=
    reloader_test.go:714: Performing step number 1
level=info msg="Reload triggered" cfg_in= cfg_out= cfg_dirs="/var/folders/77/n11x5lsj4cv7lcnln0bb5pdcwym47m/T/TestReloader_ConfigDirApplyBasedOnWatchInterval314241190/001, /var/folders/77/n11x5lsj4cv7lcnln0bb5pdcwym47m/T/TestReloader_ConfigDirApplyBasedOnWatchInterval314241190/002" watched_dirs=
    reloader_test.go:714: Performing step number 2
--- PASS: TestReloader_ConfigDirApplyBasedOnWatchInterval (1.54s)
PASS
```

### _The test steps that failed are described as below:_

* **Test Step 0**
  * Create symlink in dir2
→ fires 1st fsnotify from dir2
  * Move file to dir1
→ fires 2nd fsnotify from dir
  * In the end of test step 0, the relaoder triggers 2 reloads

* **Test Step 1**: Unexpectedly skipped, since the test steps depend on the number of reload times
* **Result**: Assertion failed at line#803.
https://github.com/thanos-io/thanos/blob/58f15ea6c047abaa62f0ea7af5d273402ff7dc92/pkg/reloader/reloader_test.go#L803
This is because test step 1 was skipped.
* **Observed log in local machine**:
```
=== RUN   TestReloader_ConfigDirApplyBasedOnWatchInterval
=== PAUSE TestReloader_ConfigDirApplyBasedOnWatchInterval
=== CONT  TestReloader_ConfigDirApplyBasedOnWatchInterval
level=info msg="reloading via HTTP"
level=info msg="started watching config file and directories for changes" cfg= cfgDirs=/var/folders/77/n11x5lsj4cv7lcnln0bb5pdcwym47m/T/TestReloader_ConfigDirApplyBasedOnWatchInterval2488444485/001,/var/folders/77/n11x5lsj4cv7lcnln0bb5pdcwym47m/T/TestReloader_ConfigDirApplyBasedOnWatchInterval2488444485/002 out= dirs=
    reloader_test.go:714: Performing step number 0
level=info msg="Reload triggered" cfg_in= cfg_out= cfg_dirs="/var/folders/77/n11x5lsj4cv7lcnln0bb5pdcwym47m/T/TestReloader_ConfigDirApplyBasedOnWatchInterval2488444485/001, /var/folders/77/n11x5lsj4cv7lcnln0bb5pdcwym47m/T/TestReloader_ConfigDirApplyBasedOnWatchInterval2488444485/002" watched_dirs=
level=info msg="Reload triggered" cfg_in= cfg_out= cfg_dirs="/var/folders/77/n11x5lsj4cv7lcnln0bb5pdcwym47m/T/TestReloader_ConfigDirApplyBasedOnWatchInterval2488444485/001, /var/folders/77/n11x5lsj4cv7lcnln0bb5pdcwym47m/T/TestReloader_ConfigDirApplyBasedOnWatchInterval2488444485/002" watched_dirs=
    reloader_test.go:714: Performing step number 2
    testutil.go:91: reloader_test.go:801: ""

        	exp: "rule3-changed"

        	got: "rule3"

        Diff:
        --- Expected
        +++ Actual
        @@ -1 +1 @@
        -rule3-changed
        +rule3


--- FAIL: TestReloader_ConfigDirApplyBasedOnWatchInterval (1.04s)
FAIL
```

## Proposed solution:
Only watch on `dir` instead of both `dir` and `dir2`, so that it will avoid redundant fsnotify event from `dir2` in test step 0.
